### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/pptx2md/outputter.py
+++ b/pptx2md/outputter.py
@@ -1,4 +1,4 @@
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 from pptx2md.global_var import g
 import re
 
@@ -34,7 +34,7 @@ class md_outputter(outputter):
 
     def put_title(self, text, level):
         text = text.strip()
-        if fuzz.ratio(text, g.last_title.get(level, '')) < 92:
+        if not fuzz.ratio(text, g.last_title.get(level, ''), score_cutoff=92):
             self.ofile.write('#'*level + ' ' + text + '\n\n')
             g.last_title[level] = text
 
@@ -74,7 +74,7 @@ class wiki_outputter(outputter):
 
     def put_title(self, text, level):
         text = text.strip()
-        if fuzz.ratio(text, g.last_title.get(level, '')) < 92:
+        if not fuzz.ratio(text, g.last_title.get(level, ''), score_cutoff=92):
             self.ofile.write('!'*level + ' ' + text + '\n\n')
             g.last_title[level] = text
 
@@ -115,7 +115,7 @@ class madoko_outputter(outputter):
 
     def put_title(self, text, level):
         text = text.strip()
-        if fuzz.ratio(text, g.last_title.get(level, '')) < 92:
+        if not fuzz.ratio(text, g.last_title.get(level, ''), score_cutoff=92):
             self.ofile.write('#'*level + ' ' + text + '\n\n')
             g.last_title[level] = text
 

--- a/pptx2md/parser.py
+++ b/pptx2md/parser.py
@@ -4,7 +4,7 @@ from pptx.enum.shapes import PP_PLACEHOLDER, MSO_SHAPE_TYPE
 from pptx.enum.dml import MSO_COLOR_TYPE, MSO_THEME_COLOR
 from PIL import Image
 import os
-from fuzzywuzzy import process as fuze_process
+from rapidfuzz import process as fuze_process
 from operator import attrgetter
 from pptx2md.global_var import g
 from pptx2md import global_var
@@ -79,12 +79,12 @@ def process_title(shape):
     global out
     text = shape.text_frame.text.strip()
     if g.use_custom_title:
-        res = fuze_process.extractOne(text, g.titles.keys())
-        if res[1] < 92:
+        res = fuze_process.extractOne(text, g.titles.keys(), score_cutoff=92)
+        if not res:
             g.max_custom_title
             out.put_title(text, g.max_custom_title + 1)
         else:
-            print(text, ' transferred to ', res[0], '. the ratio is ', res[1])
+            print(text, ' transferred to ', res[0], '. the ratio is ', round(res[1]))
             out.put_title(res[0], g.titles[res[0]])
     else:
         out.put_title(text, 1)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     },
     install_requires = [
         'python-pptx',
-        'fuzzywuzzy',
+        'rapidfuzz',
         'pillow'
     ]
 )


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy