### PR TITLE
Proper path handling for image export

### DIFF
--- a/pptx2md/__main__.py
+++ b/pptx2md/__main__.py
@@ -55,6 +55,8 @@ def main():
     if args.output:
         out_path = args.output
     
+    g.out_path = out_path
+    
     if args.image_dir:
         g.img_path = args.image_dir
 

--- a/pptx2md/outputter.py
+++ b/pptx2md/outputter.py
@@ -1,9 +1,11 @@
 from rapidfuzz import fuzz
 from pptx2md.global_var import g
 import re
+import os
 
 class outputter(object):
     def __init__(self, file_path):
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
         self.ofile = open(file_path, 'w', encoding='utf8')
     def put_title(self, text, level):
         pass
@@ -30,7 +32,7 @@ class outputter(object):
 class md_outputter(outputter):
     # write outputs to markdown
     def __init__(self, file_path):
-        self.ofile = open(file_path, 'w', encoding='utf8')
+        super().__init__(file_path)
         self.esc_re1 = re.compile(r'([\\\*`!_\{\}\[\]\(\)#\+-\.])')
         self.esc_re2 = re.compile(r'(<[^>]+>)')
 
@@ -73,7 +75,7 @@ class md_outputter(outputter):
 class wiki_outputter(outputter):
     # write outputs to wikitext
     def __init__(self, file_path):
-        self.ofile = open(file_path, 'w', encoding='utf8')
+        super().__init__(file_path)
         self.esc_re = re.compile(r'<([^>]+)>')
 
     def put_title(self, text, level):
@@ -114,7 +116,7 @@ class wiki_outputter(outputter):
 class madoko_outputter(outputter):
     # write outputs to madoko markdown
     def __init__(self, file_path):
-        self.ofile = open(file_path, 'w', encoding='utf8')
+        super().__init__(file_path)
         self.ofile.write('[TOC]\n\n')
         self.esc_re1 = re.compile(r'([\\\*`!_\{\}\[\]\(\)#\+-\.])')
         self.esc_re2 = re.compile(r'(<[^>]+>)')

--- a/pptx2md/parser.py
+++ b/pptx2md/parser.py
@@ -130,8 +130,8 @@ def process_picture(shape):
         picture_count += 1
     if pic_ext == 'wmf':
         if not g.disable_wmf:
-            Image.open(output_path).save(g.path_name_ext(g.img_path, pic_name, 'png'))
-            out.put_image(g.path_name_ext(g.img_path, pic_name, 'png'), width)
+            Image.open(output_path).save(os.path.splitext(output_path)[0]+'.png')
+            out.put_image(os.path.splitext(img_outputter_path)[0]+'.png', width)
     else:
         out.put_image(img_outputter_path, width)
 

--- a/pptx2md/parser.py
+++ b/pptx2md/parser.py
@@ -121,15 +121,19 @@ def process_picture(shape):
     if not os.path.exists(g.img_path):
         os.makedirs(g.img_path)
 
-    with open(g.path_name_ext(g.img_path, pic_name, pic_ext), 'wb') as f:
+    output_path = g.path_name_ext(g.img_path, pic_name, pic_ext)
+    common_path = os.path.commonpath([g.out_path, g.img_path])
+    img_outputter_path = os.path.relpath(output_path, common_path)
+    print(img_outputter_path)
+    with open(output_path, 'wb') as f:
         f.write(shape.image.blob)
         picture_count += 1
     if pic_ext == 'wmf':
         if not g.disable_wmf:
-            Image.open(g.path_name_ext(g.img_path, pic_name, pic_ext)).save(g.path_name_ext(g.img_path, pic_name, 'png'))
+            Image.open(output_path).save(g.path_name_ext(g.img_path, pic_name, 'png'))
             out.put_image(g.path_name_ext(g.img_path, pic_name, 'png'), width)
     else:
-        out.put_image(g.path_name_ext(g.img_path, pic_name, pic_ext), width)
+        out.put_image(img_outputter_path, width)
 
 def ungroup_shapes(shapes):
     res = []

--- a/pptx2md/parser.py
+++ b/pptx2md/parser.py
@@ -124,7 +124,6 @@ def process_picture(shape):
     output_path = g.path_name_ext(g.img_path, pic_name, pic_ext)
     common_path = os.path.commonpath([g.out_path, g.img_path])
     img_outputter_path = os.path.relpath(output_path, common_path)
-    print(img_outputter_path)
     with open(output_path, 'wb') as f:
         f.write(shape.image.blob)
         picture_count += 1


### PR DESCRIPTION
When extracting images the path to the image file within the, e.g. `markdown` file is incorrect when `output` does not point to `.` directory. This fix finds the common path of `output` and `image_path` and adjusts the paths in the, e.g. `markdown` file.

I would greatly appreciate my two PRs to be merged in the near future as well as the pip package to be updated.

Great package btw :)