### PR TITLE
feat: Add abilitity to delinate slides in markdown output

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Use it with `pptx2md [filename] -t titles.txt`.
 * `--disable-escaping` do not attempt to escape special characters
 * `--disable-wmf` keep wmf formatted image untouched (avoid exceptions under linux)
 * `--disable-color` disable color tags in HTML
+* `--enable-slides` deliniate slides `\n---\n`, this can help if you want to convert pptx slides to markdown slides
 * `--min-block-size [size]` the minimum number of characters for a text block to be outputted
 * `--wiki` / `--mdk` if you happen to be using tiddlywiki or madoko, this argument outputs the corresponding markup language
 

--- a/pptx2md/__init__.py
+++ b/pptx2md/__init__.py
@@ -40,6 +40,7 @@ def convert(
     disable_color: bool = False,  # do not add color HTML tags
     disable_escaping: bool = False,  # do not attempt to escape special characters
     disable_notes: bool = False,  # do not add presenter notes
+    enable_slides: bool = False,  # add slide deliniation
     wiki: bool = False,  # generate output as wikitext(TiddlyWiki)
     mdk: bool = False,  # generate output as madoko markdown
     min_block_size: int = 15,  # the minimum character number of a text block to be converted
@@ -101,6 +102,10 @@ def convert(
     else:
         g.disable_notes = False
 
+    if enable_slides:
+        g.enable_slides = True
+    else:
+        g.enable_slides = False
     if page is not None:
         g.page = page
 

--- a/pptx2md/__main__.py
+++ b/pptx2md/__main__.py
@@ -42,6 +42,7 @@ def parse_args():
   arg_parser.add_argument('--disable-color', help='do not add color HTML tags', action="store_true")
   arg_parser.add_argument('--disable-escaping', help='do not attempt to escape special characters', action="store_true")
   arg_parser.add_argument('--disable-notes', help='do not add presenter notes', action="store_true")
+  arg_parser.add_argument('--enable-slides', help='deliniate slides `\n---\n`', action="store_true")
   arg_parser.add_argument('--wiki', help='generate output as wikitext(TiddlyWiki)', action="store_true")
   arg_parser.add_argument('--mdk', help='generate output as madoko markdown', action="store_true")
   arg_parser.add_argument('--min-block-size',
@@ -109,6 +110,11 @@ def main():
     g.disable_notes = True
   else:
     g.disable_notes = False
+
+  if args.enable_slides:
+    g.enable_slides = True
+  else:
+    g.enable_slides = False
 
   if args.page:
     g.page = args.page

--- a/pptx2md/global_var.py
+++ b/pptx2md/global_var.py
@@ -28,6 +28,7 @@ g.disable_color = False
 # prevent escaping of characters
 g.disable_escaping = False
 g.disable_notes = False
+g.enable_slides = False
 
 # global variables
 g.titles = {}

--- a/pptx2md/parser.py
+++ b/pptx2md/parser.py
@@ -220,6 +220,8 @@ def parse(prs, outputer):
       text = slide.notes_slide.notes_text_frame.text
       if text:
         notes += process_notes(text, idx + 1)
+    if idx < len(prs.slides)-1 and g.enable_slides:
+        out.put_para("\n---\n")
   out.close()
 
   if len(notes) > 0:


### PR DESCRIPTION
I have added an arg `--enable_slides` . This option is off by default. However, when you enable   adds the pattern `\n---\n` between slides. This is the default for most markdown slide programs and thus allows ingesting pptx slide decks into markdown slide programs.

