### PR TITLE
Option --disable-wmf writes image embed code for wmf/emf files, and fix for writing emf files.

### DIFF
--- a/pptx2md/outputter.py
+++ b/pptx2md/outputter.py
@@ -361,31 +361,18 @@ class QuartoFormatter(Formatter):
                 self.put_para(":::")
 
             if slide_idx < len(presentation_data.slides) - 1 and self.config.enable_slides:
-                self.put_para("\n---\n")
+                self.put_para("\n***\n")
 
         self.close()
 
     def put_header(self):
-        self.ofile.write('''---
-title: "Presentation Title"
-author: "Author"
-format: 
-  revealjs:
-    slide-number: c/t
-    width: 1600
-    height: 900
-    logo: img/logo.png
-    footer: "Organization"
-    incremental: true
-    theme: [simple]
----
-''')
+        pass
 
     def put_title(self, text, level):
-        self.ofile.write('#' * level + ' ' + text + '\n\n')
+        self.ofile.write('\n\n' + '#' * level + ' ' + text + '\n\n')
 
     def put_list(self, text, level):
-        self.ofile.write('  ' * level + '* ' + text.strip() + '\n')
+        self.ofile.write('  ' * level + '- ' + text.strip() + '\n')
 
     def put_para(self, text):
         self.ofile.write(text + '\n\n')
@@ -403,13 +390,13 @@ format:
         self.ofile.write('\n'.join([gen_table_row(row) for row in table[1:]]) + '\n\n')
 
     def get_accent(self, text):
-        return ' _' + text + '_ '
+        return ' *' + text + '* '
 
     def get_strong(self, text):
         return ' __' + text + '__ '
 
     def get_colored(self, text, rgb):
-        return ' <span style="color:%s">%s</span> ' % (rgb_to_hex(rgb), text)
+        return ' [%s]{style="color:%s"} ' % (text, rgb_to_hex(rgb))
 
     def get_hyperlink(self, text, url):
         return '[' + text + '](' + url + ')'

--- a/pptx2md/parser.py
+++ b/pptx2md/parser.py
@@ -152,7 +152,10 @@ def process_picture(config: ConversionConfig, shape, slide_idx) -> Union[ImageEl
 
     file_prefix = ''.join(os.path.basename(config.pptx_path).split('.')[:-1])
     pic_name = file_prefix + f'_{picture_count}'
-    pic_ext = shape.image.ext
+    if shape.image.filename:
+        pic_ext = shape.image.filename.split('.')[-1]
+    else:
+        pic_ext = shape.image.ext
     if not os.path.exists(config.image_dir):
         os.makedirs(config.image_dir)
 
@@ -164,7 +167,7 @@ def process_picture(config: ConversionConfig, shape, slide_idx) -> Union[ImageEl
         picture_count += 1
 
     # normal images
-    if config.disable_wmf or pic_ext != 'wmf':
+    if config.disable_wmf or (pic_ext != 'wmf' and pic_ext != 'emf'):
         return ImageElement(path=img_outputter_path, width=config.image_width)
 
     # wmf images, try to convert, if failed, output as original

--- a/pptx2md/parser.py
+++ b/pptx2md/parser.py
@@ -44,8 +44,6 @@ from pptx2md.types import (
 
 logger = logging.getLogger(__name__)
 
-picture_count = 0
-
 
 def is_title(shape):
     if shape.is_placeholder and (shape.placeholder_format.type == PP_PLACEHOLDER.TITLE or
@@ -148,10 +146,7 @@ def process_picture(config: ConversionConfig, shape, slide_idx) -> Union[ImageEl
     if config.disable_image:
         return None
 
-    global picture_count
-
-    file_prefix = ''.join(os.path.basename(config.pptx_path).split('.')[:-1])
-    pic_name = file_prefix + f'_{picture_count}'
+    pic_name = shape.image.sha1
     if shape.image.filename:
         pic_ext = shape.image.filename.split('.')[-1]
     else:
@@ -164,7 +159,6 @@ def process_picture(config: ConversionConfig, shape, slide_idx) -> Union[ImageEl
     img_outputter_path = os.path.relpath(output_path, common_path)
     with open(output_path, 'wb') as f:
         f.write(shape.image.blob)
-        picture_count += 1
 
     # normal images
     if config.disable_wmf or (pic_ext != 'wmf' and pic_ext != 'emf'):

--- a/pptx2md/parser.py
+++ b/pptx2md/parser.py
@@ -164,7 +164,7 @@ def process_picture(config: ConversionConfig, shape, slide_idx) -> Union[ImageEl
         picture_count += 1
 
     # normal images
-    if pic_ext != 'wmf':
+    if config.disable_wmf or pic_ext != 'wmf':
         return ImageElement(path=img_outputter_path, width=config.image_width)
 
     # wmf images, try to convert, if failed, output as original


### PR DESCRIPTION
`pptx2md` has an option `--disable-wmf`, which however has no effect. The first commit is my (minimal) implementation, where the option leads to image embed code (`![](file.wmf)`) to be written to the output.

While there is to my knowledge no Markdown implementation which can actually embed WMF files, this serves as a placeholder to inform the user where the image is supposed to go. For my use, I will convert WMF files to SVG files using Inkscape and embed those, which works well with RevealJS output from Quarto.

After implementing the above, I noticed that the wmf files written by pptx2md cannot be read by Inkscape, because the file content is actually EMF (enhanced metafile). Apparently `python-pptx` has a bug (?) where `shape.image.ext` is `wmf` when it should be `emf`. In case of the PowerPoint file I worked with, the correct extension is in `shape.image.filename`. The second commit contains a fix based on that observation.