### PR TITLE
pptx2md  #69

### DIFF
--- a/pptx2md/parser.py
+++ b/pptx2md/parser.py
@@ -219,7 +219,7 @@ def process_shapes(config: ConversionConfig, current_shapes, slide_id: int) -> L
                 pic = process_picture(config, shape, slide_id)
                 if pic:
                     results.append(pic)
-            except AttributeError as e:
+            except (AttributeError, ValueError) as e:
                 logger.warning(f'Failed to process picture, skipped: {e}')
         elif shape.shape_type == MSO_SHAPE_TYPE.TABLE:
             table = process_table(config, shape, slide_id)


### PR DESCRIPTION
As mentioned in Issue #69, here is my PR :)

- python-pptx will throw a ValueError, if the lazily loaded file extension of an image is not a supported type (e.g. MPO)
    - ref. parser.py:155
- This ValueError does not get caught while processing the shapes which in turn will crash the program. 
- The simple solution is to just add ValueError to the exception tuple where it gets called in the process_shapes function.
- The other place the function gets called already has a try-except block and simply ignores all exceptions