### PR TITLE
Update pyproject.toml to declare Apache-2.0 license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "2.0.6"
 description = "This package converts pptx to markdown"
 repository = "https://github.com/ssine/pptx2md"
 authors = ["Liu Siyao <liu.siyao@qq.com>"]
-license = "MIT Licence"
+license = "Apache-2.0"
 
 [tool.poetry.scripts]
 pptx2md = "pptx2md.__main__:main"


### PR DESCRIPTION
Updates pyproject.toml license declaration to match the LICENSE file, as well as the declared license in each file in the pptx2md directory.

Uses SPDX license expression defined in https://spdx.org/licenses/ which is required by [PEP-639](https://peps.python.org/pep-0639/#spdx-license-expression-syntax)