### PR TITLE
Handle `notes_text_frame` when it is `None`

### DIFF
--- a/pptx2md/parser.py
+++ b/pptx2md/parser.py
@@ -267,7 +267,7 @@ def parse(config: ConversionConfig, prs: Presentation) -> ParsedPresentation:
             else:
                 result_slide = GeneralSlide(elements=process_shapes(config, shapes, idx + 1))
 
-        if not config.disable_notes and slide.has_notes_slide:
+        if not config.disable_notes and slide.has_notes_slide and slide.notes_slide.notes_text_frame:
             text = slide.notes_slide.notes_text_frame.text
             if text:
                 result_slide.notes.append(text)


### PR DESCRIPTION
Since otherwise some slide decks can raise `AttributeError: 'NoneType' object has no attribute 'text'` on the subsequent line `text = slide.notes_slide.notes_text_frame.text`. With this patch, the specific slide deck I had that hit this issue now parses flawlessly.